### PR TITLE
Fix cookie parsing

### DIFF
--- a/seamless/internal.py
+++ b/seamless/internal.py
@@ -13,7 +13,7 @@ class Cookies:
             return
 
         for cookie in cookie_string.split(";"):
-            key, value = cookie.split("=")
+            key, value = cookie.split("=", maxsplit=1)
             self.cookies[key.strip()] = value.strip()
 
     def __getitem__(self, key: str):


### PR DESCRIPTION
Since cookie values may contain the `=` symbol, we don't want to split the cookie string over all the `=` signs, but only by the first occurence of it.

This PR fixes this issue.