### PR TITLE
Fix typing in empty.py

### DIFF
--- a/seamless/extra/empty.py
+++ b/seamless/extra/empty.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from seamless.element import Element
 from seamless.internal import SEAMLESS_ELEMENT_ATTRIBUTE
 
@@ -8,6 +8,6 @@ if TYPE_CHECKING:
 class Empty(Element):
     tag_name = "seamless:empty"
 
-    def __init__(self, *args: "ChildrenType", **props: dict):
+    def __init__(self, *args: "ChildrenType", **props: Any):
         props[SEAMLESS_ELEMENT_ATTRIBUTE] = True
         super().__init__(*args, **props)


### PR DESCRIPTION
Since typing of `**kwargs` defines the type that *each* keyword argument must have, putting `dict` makes it only allow passing dicts as keyword arguments.

What you actually want is to allow any kind of object to passed as attribute, so this PR fixes this, putting `Any` as the type of each keyword argument.

BTW, if you want to specify a specific set of keywords without specifying them one by one, use the `typing.Unpack` type on a `typing.TypedDict`.