### PR TITLE
Fix JS and events not working properly together

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'Seamless'
 copyright = '2024, Xpo Development'
 author = 'Xpo Development'
-version = '0.8.5'
+version = '0.8.6'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/seamless/__init__.py
+++ b/seamless/__init__.py
@@ -3,7 +3,7 @@ from .html import *
 from .rendering.html import render
 from .core import JS
 
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 __all__ = [
     "Component",
     "A",

--- a/seamless/core/javascript.py
+++ b/seamless/core/javascript.py
@@ -14,11 +14,21 @@ class JavaScript:
             raise ValueError("Must specify either code or file")
         self.code = code
 
+    def __add__(self, other: "JavaScript | str") -> "JavaScript":
+        if isinstance(other, JavaScript):
+            return JavaScript(self.code + other.code)
+        elif isinstance(other, str):
+            return JavaScript(self.code + other)
+        else:
+            raise TypeError(
+                f"Cannot concatenate JavaScript with {type(other).__name__}"
+            )
+
 
 @transformer_for(lambda key, value: key == "init" and isinstance(value, JavaScript))
 def transform_init_source(key: str, source: JavaScript, props):
     props[SEAMLESS_ELEMENT_ATTRIBUTE] = True
-    props[SEAMLESS_INIT_ATTRIBUTE] = source.code
+    props[SEAMLESS_INIT_ATTRIBUTE] = props.get(SEAMLESS_INIT_ATTRIBUTE, "") + source.code
     del props[key]
 
 


### PR DESCRIPTION
This PR fixes the issue described in the title.

The issue is that when having both attributes of an event and init, the init attribute will make the event not work.

This is because the `JS` transformer always happens after the event transformer and completely replaces the previous init code.